### PR TITLE
Updated docs and installing anna script to use Python3. Included inst…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Cloudburst is a low-latency, stateful serverless programming framework built on 
 You can install Cloudburst's dependencies with `pip` and use the bash scripts included in this repository to run the system locally. You can find the Cloudburst client in `cloudburst/client/client.py`. Full documentation on starting a cluster in local mode can be found [here](docs/local-mode.md); documentation for the Cloudburst client can be found [here](docs/function-execution.md). An example interaction is modeled below.
 
 ```bash
-$ pip install -r requirements.txt
-$ ./scripts/start-cloudburst-local.sh
+$ pip3 install -r requirements.txt
+$ ./scripts/start-cloudburst-local.sh n n
 ...
-$ ./scripts/stop-cloudburst-local.sh
+$ ./scripts/stop-cloudburst-local.sh n
 ```
 
 The `CloudburstConnection` is the main client interface; when running in local mode, all interaction between the client and server happens on `localhost`. Users can register functions and execute them. The executions return `CloudburstFuture`s, which can be retrieved asynchronously via the `get` method. Users can also register DAGs (directed, acylic graphs) of functions, where results from one function will be passed to downstream functions. 

--- a/docs/local-mode.md
+++ b/docs/local-mode.md
@@ -4,9 +4,11 @@ In order to run Cloudburst, whether in local mode or in [cluster mode](https://g
 
 ## Prerequisites
 
-Cloudburst currently only supports Python3. To install Python dependencies, simply run `pip install -r requirements.txt` from the Cloudburst source directory.
+Cloudburst currently only supports Python3. To install Python dependencies, simply run `pip3 install -r requirements.txt` from the Cloudburst source directory.
 
 Before running Cloudburst, we need to compile its Protobufs locally to generate the Python dependency files. `scripts/build.sh` automatically does this for you and installs them in the correct location, but it requires having the `protoc` tool installed. If you need to remove the locally compiled protobufs, you can run `bash scripts/clean.sh`.
+
+Prepackaged scripts to install dependencies such as `protoc` on Fedora, Debian, and macOS can be found in `common/scripts/install-dependencies(-osx).sh`. To install the common submodule run `git submodule update --init --recursive`.
 
 Finally, Cloudburst requires access to the Anna Python client, which is in the Anna KVS repository. A default script to clone the Anna repository and install the client (the client is not currently `pip`-installable) can be found in `scripts/install-anna.sh`. You can customize the installation location by adding the `--prefix` flag to the `setup.py` command.
 

--- a/scripts/install-anna.sh
+++ b/scripts/install-anna.sh
@@ -17,6 +17,6 @@
 cd $HOME
 git clone --recurse-submodules https://github.com/hydro-project/anna
 cd anna/client/python
-python setup.py install
+python3 setup.py install
 cd $HOME
 rm -rf anna


### PR DESCRIPTION
…ructions on how to install the common submodule and use the prepackaged scripts to install `protoc`

Ran on a new Ubuntu 18.04 LTS EC2 t2.micro instance.

Ubuntu 18.04 LTS includes both `python` and `python3` where `python` runs python2.7. Changed pip to pip3 and in the installing anna script to python3. Using just python broke the start-cloudburst-local.sh script as cloudburst/server/scheduler/server.py uses anna, but anna was installed in python2.7.