### PR TITLE
Removes use of ordered sets for regular Python lists

### DIFF
--- a/cloudburst/shared/serializer.py
+++ b/cloudburst/shared/serializer.py
@@ -112,8 +112,6 @@ class Serializer():
         if not typ:
             if isinstance(value, set):
                 return self.dump_lattice(value, SetLattice)
-            elif isinstance(value, list):
-                return self.dump_lattice(value, OrderedSetLattice)
             else:
                 return self.dump_lattice(value, LWWPairLattice)
 


### PR DESCRIPTION
Fixes #16. As @xcharleslin pointed out, lists were being serialized as `OrderedSetLattice`s, which automatically sorts them. Switches to using `LWWPairLattice` to maintain default list order.