### PR TITLE
Fix docker image start script

### DIFF
--- a/dockerfiles/start-cloudburst.sh
+++ b/dockerfiles/start-cloudburst.sh
@@ -44,8 +44,9 @@ git checkout -b brnch origin/$ANNA_REPO_BRANCH
 git submodule sync
 git submodule update
 
+cd client/python && python3.6 setup.py install --prefix=$HOME/.local
+
 cd $HYDRO_HOME/cloudburst
-git submodule update
 if [[ -z "$REPO_ORG" ]]; then
   REPO_ORG="hydro-project"
 fi


### PR DESCRIPTION
We need to rebuild the anna python package in the start script. Otherwise the version of common/ submodule used between anna and cloudburst could be different, which leads to proto error.