### PR TITLE
Adds GPU support for Cloudburst

### DIFF
--- a/cloudburst/client/client.py
+++ b/cloudburst/client/client.py
@@ -148,7 +148,8 @@ class CloudburstConnection():
         else:
             raise RuntimeError(f'Unexpected error while registering function: {resp}.')
 
-    def register_dag(self, name, functions, connections, gpu_functions=[]):
+    def register_dag(self, name, functions, connections, gpu_functions=[],
+                     batching_functions=[]):
         '''
         Registers a new DAG with the system. This operation will fail if any of
         the functions provided cannot be identified in the system.
@@ -184,6 +185,9 @@ class CloudburstConnection():
 
             if function in gpu_functions:
                 ref.gpu = True
+
+            if function in batching_functions:
+                ref.batching = True
 
             ref.name = fname
             for invalid in invalids:

--- a/cloudburst/client/client.py
+++ b/cloudburst/client/client.py
@@ -148,7 +148,7 @@ class CloudburstConnection():
         else:
             raise RuntimeError(f'Unexpected error while registering function: {resp}.')
 
-    def register_dag(self, name, functions, connections):
+    def register_dag(self, name, functions, connections, gpu_functions=[]):
         '''
         Registers a new DAG with the system. This operation will fail if any of
         the functions provided cannot be identified in the system.
@@ -181,6 +181,9 @@ class CloudburstConnection():
             else:
                 fname = function
                 invalids = []
+
+            if function in gpu_functions:
+                ref.gpu = True
 
             ref.name = fname
             for invalid in invalids:

--- a/cloudburst/server/executor/call.py
+++ b/cloudburst/server/executor/call.py
@@ -148,7 +148,7 @@ def _run_function(func, refs, args, user_lib):
                 if isinstance(val, CloudburstReference):
                     arg[idx] = refs[val.key]
 
-                func_args += (arg,)
+            func_args += (arg,)
 
     return func(*func_args)
 
@@ -287,6 +287,9 @@ def _exec_dag_function_normal(pusher_cache, kvs, trigger_sets, function,
                               batching):
     fname = schedules[0].target_function
 
+    # We construct farg_sets to have a request by request set of arguments.
+    # That is, each element in farg_sets will have all the arguments for one
+    # invocation.
     farg_sets = []
     for schedule, trigger_set in zip(schedules, trigger_sets):
         fargs = list(schedule.arguments[fname].values)
@@ -299,8 +302,9 @@ def _exec_dag_function_normal(pusher_cache, kvs, trigger_sets, function,
 
     if batching:
         fargs = [[]] * len(farg_sets[0])
-        for idx, farg_set in enumerate(farg_sets):
-            fargs[idx].append(farg_set[idx])
+        for farg_set in farg_sets:
+            for idx, val in enumerate(farg_set):
+                fargs[idx].append(val)
     else: # There will only be one thing in farg_sets
         fargs = farg_sets[0]
 

--- a/cloudburst/server/executor/server.py
+++ b/cloudburst/server/executor/server.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import logging
+import os
 import sys
 import time
 
@@ -32,6 +33,7 @@ from cloudburst.shared.proto.cloudburst_pb2 import (
     MULTIEXEC # Cloudburst's execution types
 )
 from cloudburst.shared.proto.internal_pb2 import (
+    CPU, GPU, # Cloudburst's executor types
     ExecutorStatistics,
     ThreadStatus,
 )
@@ -42,6 +44,12 @@ REPORT_THRESH = 5
 def executor(ip, mgmt_ip, schedulers, thread_id):
     logging.basicConfig(filename='log_executor.txt', level=logging.INFO,
                         format='%(asctime)s %(message)s')
+
+    # Check what resources we have access to, set as an environment variable.
+    if os.getenv('EXECUTOR_TYPE', 'CPU') == 'GPU':
+        exec_type = GPU
+    else:
+        exec_type = CPU
 
     context = zmq.Context(1)
     poller = zmq.Poller()
@@ -95,6 +103,7 @@ def executor(ip, mgmt_ip, schedulers, thread_id):
     status.ip = ip
     status.tid = thread_id
     status.running = True
+    status.type = exec_type
     utils.push_status(schedulers, pusher_cache, status)
 
     departing = False

--- a/cloudburst/server/executor/server.py
+++ b/cloudburst/server/executor/server.py
@@ -305,7 +305,7 @@ def executor(ip, mgmt_ip, schedulers, thread_id):
             # Only execute the functions for which we have received a schedule.
             # Everything else will wait.
             for tid, fname in list(trigger_keys):
-                if tid not in queue[fname]:
+                if fname not in queue or tid not in queue[fname]:
                     trigger_keys.remove((tid, fname))
 
             if len(trigger_keys) == 0:

--- a/cloudburst/server/executor/utils.py
+++ b/cloudburst/server/executor/utils.py
@@ -42,6 +42,7 @@ def generate_error_response(schedule, client, fname):
         result = serializer.dump_lattice(result, MultiKeyCausalLattice)
         client.causal_put(schedule.output_key, result)
 
+
 def retrieve_function(name, kvs, user_library, consistency=NORMAL):
     kvs_name = sutils.get_func_kvs_name(name)
 

--- a/cloudburst/server/scheduler/create.py
+++ b/cloudburst/server/scheduler/create.py
@@ -42,7 +42,8 @@ def create_function(func_create_socket, kvs, consistency=NORMAL):
 
     if consistency == NORMAL:
         body = LWWPairLattice(sutils.generate_timestamp(0), func.body)
-        kvs.put(name, body)
+        res = kvs.put(name, body)
+        logging.info('kvs.put was %s' % (str(res)))
     else:
         skcl = SingleKeyCausalLattice(sutils.DEFAULT_VC,
                                       SetLattice({func.body}))

--- a/cloudburst/server/scheduler/policy/default_policy.py
+++ b/cloudburst/server/scheduler/policy/default_policy.py
@@ -19,7 +19,10 @@ import time
 import zmq
 
 from cloudburst.shared.proto.cloudburst_pb2 import GenericResponse
-from cloudburst.shared.proto.internal_pb2 import PinFunction
+from cloudburst.shared.proto.internal_pb2 import (
+    CPU, GPU, # Cloudburst's executor types
+    PinFunction
+)
 from cloudburst.shared.proto.shared_pb2 import StringSet
 from cloudburst.server.scheduler.policy.base_policy import (
     BaseCloudburstSchedulerPolicy
@@ -61,7 +64,13 @@ class DefaultCloudburstSchedulerPolicy(BaseCloudburstSchedulerPolicy):
         self.key_locations = {}
 
         # Executors which currently have no functions pinned on them.
-        self.unpinned_executors = set()
+        self.unpinned_cpu_executors = set()
+
+        # The subset of all executors that have access to GPUs and are
+        # currently unallocated.
+        # NOTE: We currently only support GPU executors # as a part of DAG
+        # requests.
+        self.unpinned_gpu_executors = set()
 
         # A map from function names to the executor(s) on which they are
         # pinned.
@@ -78,15 +87,8 @@ class DefaultCloudburstSchedulerPolicy(BaseCloudburstSchedulerPolicy):
         # rather than by policy.
         self.random_threshold = random_threshold
 
-        self.unique_executors = set()
-
         # Indicates if we are running in local mode
         self.local = local
-
-    def get_unique_executors(self):
-        count = len(self.unique_executors)
-        self.unique_executors = set()
-        return count
 
     def pick_executor(self, references, function_name=None):
         # Construct a map which maps from IP addresses to the number of
@@ -97,7 +99,7 @@ class DefaultCloudburstSchedulerPolicy(BaseCloudburstSchedulerPolicy):
         if function_name:
             executors = set(self.function_locations[function_name])
         else:
-            executors = set(self.unpinned_executors)
+            executors = set(self.unpinned_cpu_executors)
 
         for executor in self.backoff:
             executors.discard(executor)
@@ -157,9 +159,7 @@ class DefaultCloudburstSchedulerPolicy(BaseCloudburstSchedulerPolicy):
         # Remove this IP/tid pair from the system's metadata until it notifies
         # us that it is available again, but only do this for non-DAG requests.
         if not self.local and not function_name:
-            self.unpinned_executors.discard(max_ip)
-
-        self.unique_executors.add(max_ip)
+            self.unpinned_cpu_executors.discard(max_ip)
 
         if not max_ip:
             logging.error('No available executors.')
@@ -169,7 +169,9 @@ class DefaultCloudburstSchedulerPolicy(BaseCloudburstSchedulerPolicy):
     def pin_function(self, dag_name, function_ref):
         # If there are no functions left to choose from, then we return None,
         # indicating that we ran out of resources to use.
-        if len(self.unpinned_executors) == 0:
+        if function_ref.gpu and len(self.unpinned_gpu_executors) == 0:
+            return False
+        elif not function_ref.gpu and len(self.unpinned_cpu_executors) == 0:
             return False
 
         if dag_name not in self.pending_dags:
@@ -177,7 +179,12 @@ class DefaultCloudburstSchedulerPolicy(BaseCloudburstSchedulerPolicy):
 
         # Make a copy of the set of executors, so that we don't modify the
         # system's metadata.
-        candidates = set(self.unpinned_executors)
+        if function_ref.gpu:
+            candidates = set(self.unpinned_gpu_executors)
+        else:
+            # If this is not a GPU function, just look at all of the unpinned
+            # executors.
+            candidates = set(self.unpinned_cpu_executors)
 
         # Construct a PinFunction message to be sent to executors.
         pin_msg = PinFunction()
@@ -204,11 +211,15 @@ class DefaultCloudburstSchedulerPolicy(BaseCloudburstSchedulerPolicy):
 
             # Do not use this executor either way: If it rejected, it has
             # something else pinned, and if it accepted, it has pinned what we
-            # just asked it to pin.
-            # In local model allow executors to have multiple functions pinned
+            # just asked it to pin. In local mode, however we allow executors
+            # to have multiple functions pinned.
             if not self.local:
-                self.unpinned_executors.discard((node, tid))
-                candidates.discard((node, tid))
+                if function_ref.gpu:
+                    self.unpinned_gpu_executors.discard((node, tid))
+                    candidates.discard((node, tid))
+                else:
+                    self.unpinned_cpu_executors.discard((node, tid))
+                    candidates.discard((node, tid))
 
             if response.success:
                 # The pin operation succeeded, so we return the node and thread
@@ -268,11 +279,18 @@ class DefaultCloudburstSchedulerPolicy(BaseCloudburstSchedulerPolicy):
 
                 del self.thread_statuses[key]
 
-            self.unpinned_executors.discard(key)
+            if status.type == CPU:
+                self.unpinned_cpu_executors.discard(key)
+            else:
+                self.unpinned_gpu_executors.discard(key)
+
             return
 
         if len(status.functions) == 0:
-            self.unpinned_executors.add(key)
+            if status.type == CPU:
+                self.unpinned_cpu_executors.add(key)
+            else:
+                self.unpinned_gpu_executors.add(key)
 
         # Remove all the old function locations, and all the new ones -- there
         # will probably be a large overlap, but this shouldn't be much

--- a/cloudburst/server/scheduler/policy/default_policy.py
+++ b/cloudburst/server/scheduler/policy/default_policy.py
@@ -189,6 +189,7 @@ class DefaultCloudburstSchedulerPolicy(BaseCloudburstSchedulerPolicy):
         # Construct a PinFunction message to be sent to executors.
         pin_msg = PinFunction()
         pin_msg.name = function_ref.name
+        pin_msg.batching = function_ref.batching
         pin_msg.response_address = self.ip
 
         serialized = pin_msg.SerializeToString()

--- a/cloudburst/server/scheduler/utils.py
+++ b/cloudburst/server/scheduler/utils.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import logging
 import zmq
 
 from anna.lattices import SetLattice
@@ -49,7 +50,8 @@ def put_func_list(client, funclist):
         result.add(bytes(val, 'utf-8'))
 
     lattice = SetLattice(result)
-    client.put(FUNCOBJ, lattice)
+    res = client.put(FUNCOBJ, lattice)
+    logging.info('kvs.put of list was %s' % (str(res)))
 
 
 def get_cache_ip_key(ip):

--- a/cloudburst/server/scheduler/utils.py
+++ b/cloudburst/server/scheduler/utils.py
@@ -49,7 +49,7 @@ def put_func_list(client, funclist):
         result.add(bytes(val, 'utf-8'))
 
     lattice = SetLattice(result)
-    res = client.put(FUNCOBJ, lattice)
+    client.put(FUNCOBJ, lattice)
 
 
 def get_cache_ip_key(ip):

--- a/dockerfiles/cloudburst-gpu.dockerfile
+++ b/dockerfiles/cloudburst-gpu.dockerfile
@@ -1,0 +1,56 @@
+#  Copyright 2019 U.C. Berkeley RISE Lab
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+FROM hydroproject/base-cuda
+
+MAINTAINER Vikram Sreekanti <vsreekanti@gmail.com> version: 0.1
+
+ARG repo_org=hydro-project
+ARG source_branch=master
+ARG build_branch=docker-build
+
+USER root
+
+# Download latest version of the code from relevant repository & branch -- if
+# none are specified, we use hydro-project/cloudburst by default. Install the KVS
+# client from the Anna project.
+WORKDIR $HYDRO_HOME/cloudburst
+RUN git remote remove origin && git remote add origin https://github.com/$repo_org/cloudburst
+RUN git fetch -p origin && git checkout -b $build_branch origin/$source_branch
+RUN rm -rf /usr/lib/python3/dist-packages/yaml
+RUN rm -rf /usr/lib/python3/dist-packages/PyYAML-*
+RUN pip3 install -r requirements.txt
+
+WORKDIR $HYDRO_HOME
+RUN rm -rf anna
+RUN git clone --recurse-submodules https://github.com/hydro-project/anna
+WORKDIR anna
+RUN cd client/python && python3.6 setup.py install --prefix=$HOME/.local
+WORKDIR /
+
+# These installations are currently pipeline specific until we figure out a
+# better way to do package management for Python.
+RUN pip3 install torchvision torch Pillow scikit-image
+
+WORKDIR /
+RUN git clone https://github.com/vsreekanti/flow
+RUN cd flow && python3.6 setup.py install
+
+RUN rm -rf /root/.local/
+
+COPY start-cloudburst.sh /start-cloudburst.sh
+
+RUN apt-get install -y net-tools
+
+CMD bash start-cloudburst.sh

--- a/dockerfiles/import-models.py
+++ b/dockerfiles/import-models.py
@@ -1,0 +1,18 @@
+import os
+
+import torch
+import torchvision
+
+tpath = os.path.join(os.getenv('TORCH_HOME'), 'checkpoints')
+
+resnet = torchvision.models.resnet101(pretrained=True)
+resnet.eval()
+torch.save(resnet, os.path.join(tpath, 'resnet101.model'))
+
+incept = torchvision.models.inception_v3(pretrained=True)
+incept.eval()
+torch.save(resnet, os.path.join(tpath, 'inception_v3.model'))
+
+alexnet = torchvision.models.alexnet(pretrained=True)
+alexnet.eval()
+torch.save(resnet, os.path.join(tpath, 'alexnet.model'))

--- a/dockerfiles/start-cloudburst.sh
+++ b/dockerfiles/start-cloudburst.sh
@@ -36,7 +36,10 @@ gen_yml_list() {
 cd $HYDRO_HOME/anna
 git remote remove origin
 git remote add origin https://github.com/$ANNA_REPO_ORG/anna
-git fetch -p origin
+while !(git fetch -p origin); do
+   echo "git fetch failed, retrying..."
+done
+
 git checkout -b brnch origin/$ANNA_REPO_BRANCH
 git submodule sync
 git submodule update
@@ -45,7 +48,6 @@ cd client/python
 python3.6 setup.py install
 
 cd $HYDRO_HOME/cloudburst
-git submodule update
 if [[ -z "$REPO_ORG" ]]; then
   REPO_ORG="hydro-project"
 fi
@@ -56,7 +58,10 @@ fi
 
 git remote remove origin
 git remote add origin https://github.com/$REPO_ORG/cloudburst
-git fetch -p origin
+while !(git fetch -p origin); do
+   echo "git fetch failed, retrying..."
+done
+
 git checkout -b brnch origin/$REPO_BRANCH
 git submodule sync
 git submodule update
@@ -98,15 +103,10 @@ elif [[ "$ROLE" = "scheduler" ]]; then
 
   python3.6 cloudburst/server/scheduler/server.py
 elif [[ "$ROLE" = "benchmark" ]]; then
-  # echo "benchmark:" >> conf/cloudburst-config.yml
-  # echo "    cloudburst_address: $FUNCTION_ADDR" >> conf/cloudburst-config.yml
-  # echo "    thread_id: $THREAD_ID" >> conf/cloudburst-config.yml
+  echo "benchmark:" >> conf/cloudburst-config.yml
+  echo "    cloudburst_address: $FUNCTION_ADDR" >> conf/cloudburst-config.yml
+  echo "    thread_id: $THREAD_ID" >> conf/cloudburst-config.yml
 
-  # python3.6 cloudburst/server/benchmarks/server.py
-  python3.6 setup.py install --prefix=/usr/local
-  ./scripts/build.sh
-
-  cd /flow
-  python3.6 flow/benchmarks/server.py $IP
+  python3.6 cloudburst/server/benchmarks/server.py
 fi
 

--- a/dockerfiles/start-cloudburst.sh
+++ b/dockerfiles/start-cloudburst.sh
@@ -14,7 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-IP=`ifconfig eth0 | grep 'inet addr:' | grep -v '127.0.0.1' | cut -d: -f2 | awk '{ print $1 }'`
+IP=`ifconfig eth0 | grep 'inet' | grep -v inet6 | sed -e 's/^[ \t]*//' | cut -d' ' -f2`
 
 # A helper function that takes a space separated list and generates a string
 # that parses as a YAML list.
@@ -36,17 +36,16 @@ gen_yml_list() {
 cd $HYDRO_HOME/anna
 git remote remove origin
 git remote add origin https://github.com/$ANNA_REPO_ORG/anna
-while ! (git fetch -p origin)
-do
-  echo "git fetch failed, retrying"
-done
+git fetch -p origin
 git checkout -b brnch origin/$ANNA_REPO_BRANCH
 git submodule sync
 git submodule update
 
-cd client/python && python3.6 setup.py install --prefix=$HOME/.local
+cd client/python
+python3.6 setup.py install
 
 cd $HYDRO_HOME/cloudburst
+git submodule update
 if [[ -z "$REPO_ORG" ]]; then
   REPO_ORG="hydro-project"
 fi
@@ -57,16 +56,18 @@ fi
 
 git remote remove origin
 git remote add origin https://github.com/$REPO_ORG/cloudburst
-while ! (git fetch -p origin)
-do
-  echo "git fetch failed, retrying"
-done
+git fetch -p origin
 git checkout -b brnch origin/$REPO_BRANCH
 git submodule sync
 git submodule update
 
 # Compile protobufs and run other installation procedures before starting.
 ./scripts/build.sh
+
+cd /flow
+git pull origin master
+python3.6 setup.py install
+cd $HYDRO_HOME/cloudburst
 
 touch conf/cloudburst-config.yml
 echo "ip: $IP" >> conf/cloudburst-config.yml
@@ -97,10 +98,15 @@ elif [[ "$ROLE" = "scheduler" ]]; then
 
   python3.6 cloudburst/server/scheduler/server.py
 elif [[ "$ROLE" = "benchmark" ]]; then
-  echo "benchmark:" >> conf/cloudburst-config.yml
-  echo "    cloudburst_address: $FUNCTION_ADDR" >> conf/cloudburst-config.yml
-  echo "    thread_id: $THREAD_ID" >> conf/cloudburst-config.yml
+  # echo "benchmark:" >> conf/cloudburst-config.yml
+  # echo "    cloudburst_address: $FUNCTION_ADDR" >> conf/cloudburst-config.yml
+  # echo "    thread_id: $THREAD_ID" >> conf/cloudburst-config.yml
 
-  python3.6 cloudburst/server/benchmarks/server.py
+  # python3.6 cloudburst/server/benchmarks/server.py
+  python3.6 setup.py install --prefix=/usr/local
+  ./scripts/build.sh
+
+  cd /flow
+  python3.6 flow/benchmarks/server.py $IP
 fi
 

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -124,4 +124,7 @@ message PinFunction {
 
   // The address to which the executor should accept or reject the pin request.
   string response_address = 2;
+
+  // Whethher or not this function supports batching.
+  bool batching = 3;
 }

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -14,6 +14,17 @@
 
 syntax = "proto3";
 
+// An enum representing the types of resources this executor thread has access
+// to. Currently, we only support CPUs and GPUs.
+enum ExecutorType {
+  // The default ExecutorType for all threads, which says that this executor
+  // thread only has a CPU available.
+  CPU = 0;
+
+  // Indicates that this executor thread has access to a GPU.
+  GPU = 1;
+}
+
 // A status update sent from executors to schedulers, giving the schedulers
 // useful information about what resources are available in the system.
 message ThreadStatus {
@@ -34,6 +45,10 @@ message ThreadStatus {
   // executor is clearing its queues and leaving the system, and the schedulers
   // should no longer send it any work.
   bool running = 5;
+
+  // The type of resources this executor has access to (see ExecutorType
+  // definition for more details).
+  ExecutorType type = 6;
 }
 
 // A periodic reporting of the functions being executed by each executor, and

--- a/scripts/travis/docker-build.sh
+++ b/scripts/travis/docker-build.sh
@@ -19,11 +19,14 @@
 if [[ "$TRAVIS_BRANCH" = "master" ]] && [[ "$TRAVIS_PULL_REQUEST" = "false" ]]; then
   docker pull hydroproject/base
   docker pull hydroproject/cloudburst
+  docker pull hydroproject/cloudburst-gpu
 
   cd dockerfiles
   docker build . -f cloudburst.dockerfile -t hydroproject/cloudburst
+  docker build . -f cloudburst-gpu.dockerfile -t hydroproject/cloudburst-gpu
 
   echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
   docker push hydroproject/cloudburst
+  docker push hydroproject/cloudburst-gpu
 fi

--- a/tests/server/executor/test_call.py
+++ b/tests/server/executor/test_call.py
@@ -391,8 +391,8 @@ class TestExecutorCall(unittest.TestCase):
         dag = create_linear_dag([func], [fname], self.kvs_client, 'dag')
         schedule, triggers = self._create_fn_schedule(dag, arg, fname, [fname])
 
-        exec_dag_function(self.pusher_cache, self.kvs_client, triggers, func,
-                          schedule, self.user_library, {}, {}, [])
+        exec_dag_function(self.pusher_cache, self.kvs_client, [triggers], func,
+                          [schedule], self.user_library, {}, {}, [], False)
 
         # Assert that there have been 0 messages sent.
         self.assertEqual(len(self.socket.outbox), 0)
@@ -429,8 +429,8 @@ class TestExecutorCall(unittest.TestCase):
         kv.key = 'dependency'
         DEFAULT_VC.serialize(kv.vector_clock)
 
-        exec_dag_function(self.pusher_cache, self.kvs_client, triggers, func,
-                          schedule, self.user_library, {}, {}, [])
+        exec_dag_function(self.pusher_cache, self.kvs_client, [triggers], func,
+                          [schedule], self.user_library, {}, {}, [], False)
 
         # Assert that there have been 0 messages sent.
         self.assertEqual(len(self.socket.outbox), 0)
@@ -473,8 +473,8 @@ class TestExecutorCall(unittest.TestCase):
         schedule, triggers = self._create_fn_schedule(dag, arg, iname, [iname,
                                                                         sname])
 
-        exec_dag_function(self.pusher_cache, self.kvs_client, triggers, incr,
-                          schedule, self.user_library, {}, {}, [])
+        exec_dag_function(self.pusher_cache, self.kvs_client, [triggers], incr,
+                          [schedule], self.user_library, {}, {}, [], False)
 
         # Assert that there has been a message sent.
         self.assertEqual(len(self.pusher_cache.socket.outbox), 1)
@@ -511,8 +511,8 @@ class TestExecutorCall(unittest.TestCase):
         schedule, triggers = self._create_fn_schedule(dag, arg, iname,
                                                       [iname, sname], MULTI)
 
-        exec_dag_function(self.pusher_cache, self.kvs_client, triggers, incr,
-                          schedule, self.user_library, {}, {}, [])
+        exec_dag_function(self.pusher_cache, self.kvs_client, [triggers], incr,
+                          [schedule], self.user_library, {}, {}, [], False)
 
         # Assert that there has been a message sent.
         self.assertEqual(len(self.pusher_cache.socket.outbox), 1)
@@ -556,8 +556,8 @@ class TestExecutorCall(unittest.TestCase):
             dag, CloudburstReference(arg_name, True), iname, [iname, sname],
             MULTI)
 
-        exec_dag_function(self.pusher_cache, self.kvs_client, triggers, incr,
-                          schedule, self.user_library, {}, {}, [])
+        exec_dag_function(self.pusher_cache, self.kvs_client, [triggers], incr,
+                          [schedule], self.user_library, {}, {}, [], False)
 
         # Assert that there has been a message sent.
         self.assertEqual(len(self.pusher_cache.socket.outbox), 1)
@@ -610,10 +610,10 @@ class TestExecutorCall(unittest.TestCase):
                                                       [iname, sname])
 
         result = exec_dag_function(self.pusher_cache, self.kvs_client,
-                                   triggers, square, schedule,
-                                   self.user_library, {}, {}, [])
+                                   [triggers], square, [schedule],
+                                   self.user_library, {}, {}, [], False)
 
-        self.assertFalse(result)
+        self.assertFalse(result[0])
         data = self.kvs_client.get(schedule.id)
         self.assertEqual(data[schedule.id], None)
 
@@ -637,8 +637,8 @@ class TestExecutorCall(unittest.TestCase):
                                                       [iname, sname])
 
         result = exec_dag_function(self.pusher_cache, self.kvs_client,
-                                   triggers, square, schedule,
-                                   self.user_library, {}, {}, [])
+                                   [triggers], square, [schedule],
+                                   self.user_library, {}, {}, [], False)
 
         self.assertTrue(result)
         data = self.kvs_client.get(schedule.id)

--- a/tests/server/executor/test_pin.py
+++ b/tests/server/executor/test_pin.py
@@ -68,7 +68,7 @@ class TestExecutorPin(unittest.TestCase):
         # Execute the pin operation.
         pin(self.socket, self.pusher_cache, self.kvs_client, self.status,
             self.pinned_functions, self.runtimes, self.exec_counts,
-            self.user_library, False)
+            self.user_library, False, False)
 
         # Check that the correct messages were sent and the correct metadata
         # created.
@@ -108,7 +108,7 @@ class TestExecutorPin(unittest.TestCase):
         # Execute the pin operation.
         pin(self.socket, self.pusher_cache, self.kvs_client, self.status,
             self.pinned_functions, self.runtimes, self.exec_counts,
-            self.user_library, False)
+            self.user_library, False, False)
 
         # Check that the correct messages were sent and the correct metadata
         # created.

--- a/tests/server/scheduler/policy/test_default_policy.py
+++ b/tests/server/scheduler/policy/test_default_policy.py
@@ -59,7 +59,7 @@ class TestDefaultSchedulerPolicy(unittest.TestCase):
         self.policy.running_counts.clear()
         self.policy.backoff.clear()
         self.policy.key_locations.clear()
-        self.policy.unpinned_executors.clear()
+        self.policy.unpinned_cpu_executors.clear()
         self.policy.function_locations.clear()
         self.policy.pending_dags.clear()
         self.policy.thread_statuses.clear()
@@ -73,7 +73,7 @@ class TestDefaultSchedulerPolicy(unittest.TestCase):
         # Create two executors, one of which has received too many requests,
         # and the other of which has reported high load.
         address_set = {(self.ip, 1), (self.ip, 2)}
-        self.policy.unpinned_executors.update(address_set)
+        self.policy.unpinned_cpu_executors.update(address_set)
 
         self.policy.backoff[(self.ip, 1)] = time.time()
         self.policy.running_counts[self.ip, 2] = set()
@@ -93,7 +93,7 @@ class TestDefaultSchedulerPolicy(unittest.TestCase):
         '''
         # Create two unpinned executors.
         address_set = {(self.ip, 1), (self.ip, 2)}
-        self.policy.unpinned_executors.update(address_set)
+        self.policy.unpinned_cpu_executors.update(address_set)
 
         # Create one failing and one successful response.
         self.pin_socket.inbox.append(sutils.ok_resp)
@@ -105,7 +105,7 @@ class TestDefaultSchedulerPolicy(unittest.TestCase):
 
         # Ensure that both remaining executors have been removed from unpinned
         # and that the DAG commit is pending.
-        self.assertEqual(len(self.policy.unpinned_executors), 0)
+        self.assertEqual(len(self.policy.unpinned_cpu_executors), 0)
         self.assertEqual(len(self.policy.pending_dags), 1)
 
     def test_process_status(self):
@@ -132,7 +132,7 @@ class TestDefaultSchedulerPolicy(unittest.TestCase):
 
         key = (status.ip, status.tid)
 
-        self.assertTrue(key not in self.policy.unpinned_executors)
+        self.assertTrue(key not in self.policy.unpinned_cpu_executors)
         self.assertTrue(key in self.policy.function_locations[function_name])
         self.assertTrue(key in self.policy.backoff)
 
@@ -168,7 +168,7 @@ class TestDefaultSchedulerPolicy(unittest.TestCase):
         self.policy.process_status(status)
 
         self.assertEqual(len(self.policy.function_locations[function_name]), 0)
-        self.assertTrue(key in self.policy.unpinned_executors)
+        self.assertTrue(key in self.policy.unpinned_cpu_executors)
 
     def test_process_status_not_running(self):
         '''
@@ -202,7 +202,7 @@ class TestDefaultSchedulerPolicy(unittest.TestCase):
         self.policy.process_status(status)
 
         self.assertTrue(key not in self.policy.thread_statuses)
-        self.assertTrue(key not in self.policy.unpinned_executors)
+        self.assertTrue(key not in self.policy.unpinned_cpu_executors)
         self.assertEqual(len(self.policy.function_locations[function_name]), 0)
 
     def test_metadata_update(self):

--- a/tests/server/scheduler/test_call.py
+++ b/tests/server/scheduler/test_call.py
@@ -65,7 +65,7 @@ class TestSchedulerCall(unittest.TestCase):
         status.ip = self.ip
         status.tid = 0
         self.executor_key = (status.ip, status.tid)
-        self.policy.unpinned_executors.add(self.executor_key)
+        self.policy.unpinned_cpu_executors.add(self.executor_key)
 
     '''
     INDIVIDUAL FUNCTION CALL TESTS
@@ -118,7 +118,7 @@ class TestSchedulerCall(unittest.TestCase):
         # Add a new executor for which we will construct cached references.
         ip_address = '192.168.0.1'
         new_key = (ip_address, 2)
-        self.policy.unpinned_executors.add(new_key)
+        self.policy.unpinned_cpu_executors.add(new_key)
 
         # Create a new reference and add its metadata.
         ref_name = 'reference'
@@ -163,7 +163,7 @@ class TestSchedulerCall(unittest.TestCase):
         '''
         # Clear all executors from the system.
         self.policy.thread_statuses.clear()
-        self.policy.unpinned_executors.clear()
+        self.policy.unpinned_cpu_executors.clear()
 
         # Create a function call.
         call = FunctionCall()


### PR DESCRIPTION
* Adds two-class scheduling (for GPUs and CPUs) to the scheduler policy.
* Enables batching on the executor side -- if a request is marked as batching-capable, we dequeue multiple schedules and multiple DAG triggers and pass in lists of objects instead of individual objects. Most of the changes in this PR are around rewriting the executor stack to accept more than one function execution at a time.
* Adds new Dockerfiles for GPU-enabled Cloudburst executors with CUDA support. Those Dockerfiles required moving to Ubuntu 18.04, which also required changing the way we pick out node IPs.
